### PR TITLE
Store the 2D tables as a hash table

### DIFF
--- a/driver_table_reader.c
+++ b/driver_table_reader.c
@@ -3,16 +3,29 @@
 #include <stdlib.h>
 #include "driver_table_reader.h"
 
+// size of char buffer for reading in lines
+#define BUFFSIZE 256
+//
+// compile-time information to configure the hashing function
+//
+// logR labels look like:
+// [-7.4, -7.2, -7.0, ...]
+#define LOGR0 (-7.4)
+#define LOGR_STEP 0.2
 // dimensions (number of) labels in logR
 #define DIM_FAST 56
+// logT labels look like:
+// [4.9, 5.0, 5.1, ...]
+#define LOGT0 (4.9)
+#define LOGT_STEP 0.1
 // dimensions (number of) labels in logT
 #define DIM_SLOW 22
+
 // returns the floor index of the table in the collection
 // assumes a particular distribution of labels in logT and logR
 int hash_label(double logT, double logR) {
-  int index_j, index_k;
-  index_j = (logR + 7.4) / 0.2;  
-  index_k = (logT - 4.9) / 0.1;
+  int index_j = (logR - LOGR0) / LOGR_STEP;  
+  int index_k = (logT - LOGT0) / LOGT_STEP;
   return index_k * DIM_FAST + index_j;
 }
 
@@ -46,7 +59,7 @@ TableRow *get_table_row(TableCollection *collection, int i,
 // loads a 2D table into the memory specified by index j and k
 // from a file specified 
 void load_tables(TableCollection *collection, FILE *file) {
-  char buff[256];
+  char buff[BUFFSIZE];
 
   int i = 0;
   double logT, logR;
@@ -55,8 +68,7 @@ void load_tables(TableCollection *collection, FILE *file) {
     // check if the line starts with the comment line char
     if (buff[0]=='#') {
       i = 0; // reset the row_label index since new table
-      // some comment lines contain information about the table
-      // this updates the array of log_Ts and log_Rs
+      // some comment lines contain table labels
       sscanf(buff, "%*s %lf %lf", &(logT), &(logR));
       continue;
     };

--- a/driver_table_reader.c
+++ b/driver_table_reader.c
@@ -3,11 +3,25 @@
 #include <stdlib.h>
 #include "driver_table_reader.h"
 
+// returns the index of the table in the collection
+// should automatically give the floor index
+int hash_label(double logT, double logR) {
+  int index_j, index_k;
+  index_j = (logR + 7.4) / 0.2;  
+  index_k = (logT - 4.9) / 0.1;
+  return index_k * DIM_FAST + index_j;
+}
+
 // returns a pointer to a table in the collection
 // j is index in R (log_R)
 // k is index in temp (log_T K)
 SizedTable *get_table(TableCollection *collection, int j, int k) {
   return &(collection->table[DIM_FAST * k + j]);
+}
+
+SizedTable *get_table_from_key(TableCollection *collection, double logT, double logR) {
+  int table_index = hash_label(logT, logR);
+  return &(collection->table[table_index]);
 }
 
 // returns a pointer to the row in a table collection
@@ -16,6 +30,11 @@ SizedTable *get_table(TableCollection *collection, int j, int k) {
 // k is index in temp (log_T K)
 TableRow *get_table_row(TableCollection *collection, int i, int j, int k) {
   SizedTable *table = get_table(collection, j, k);
+  return &(table->row[i]);
+}
+
+TableRow *get_table_row_from_key(TableCollection *collection, int i, double logT, double logR) {
+  SizedTable *table = get_table_from_key(collection, logT, logR);
   return &(table->row[i]);
 }
 
@@ -35,7 +54,9 @@ void load_table(TableCollection *collection, FILE *file, int j, int k) {
       continue;
     };
 
-    TableRow *row = get_table_row(collection, i, j, k);
+    TableRow *row = 
+      get_table_row_from_key(collection, i, collection->log_Ts[k],
+                                            collection->log_Rs[j]);
     sscanf(buff, "%lf %lf %lf %lf %lf %lf %lf", 
       &(collection->row_labels[i]),  // row label is the first entry
       &row->entry[0], 
@@ -75,3 +96,4 @@ void initialise_tables_from_file(TableCollection *collection, char *filename) {
 void drop_tables(TableCollection *collection) {
   free(collection->table);
 }
+

--- a/driver_table_reader.c
+++ b/driver_table_reader.c
@@ -5,6 +5,7 @@
 
 // returns the index of the table in the collection
 // should automatically give the floor index
+// information about the logT and logR arrays is stored here
 int hash_label(double logT, double logR) {
   int index_j, index_k;
   index_j = (logR + 7.4) / 0.2;  
@@ -33,30 +34,31 @@ TableRow *get_table_row(TableCollection *collection, int i, int j, int k) {
   return &(table->row[i]);
 }
 
-TableRow *get_table_row_from_key(TableCollection *collection, int i, double logT, double logR) {
+TableRow *get_table_row_from_key(TableCollection *collection, int i, 
+                                 double logT, double logR) {
   SizedTable *table = get_table_from_key(collection, logT, logR);
   return &(table->row[i]);
 }
 
 // loads a 2D table into the memory specified by index j and k
 // from a file specified 
-void load_table(TableCollection *collection, FILE *file, int j, int k) {
+void load_tables(TableCollection *collection, FILE *file) {
   char buff[1024];
 
   int i = 0;
+  double logT, logR;
   // condition to capture end of file and end of table
-  while (fgets(buff, sizeof(buff), file)&&(i<DIM_ROWS)) {
+  while (fgets(buff, sizeof(buff), file)) {
     // check if the line starts with the comment line char
     if (buff[0]=='#') {
+      i = 0; // reset the energies index to 0
       // some comment lines contain information about the table
       // this updates the array of log_Ts and log_Rs
-      sscanf(buff, "%*s %lf %lf", &(collection->log_Ts[k]), &(collection->log_Rs[j]));
+      sscanf(buff, "%*s %lf %lf", &(logT), &(logR));
       continue;
     };
 
-    TableRow *row = 
-      get_table_row_from_key(collection, i, collection->log_Ts[k],
-                                            collection->log_Rs[j]);
+    TableRow *row = get_table_row_from_key(collection, i, logT, logR);
     sscanf(buff, "%lf %lf %lf %lf %lf %lf %lf", 
       &(collection->row_labels[i]),  // row label is the first entry
       &row->entry[0], 
@@ -78,13 +80,8 @@ void initialise_table(TableCollection *collection, FILE *file) {
   if (collection->table == NULL) {
     printf("Error allocating for table data");
   };
-
   // read in all the 2D subtables
-  for (int k=0; (k < DIM_SLOW); k++) {
-    for (int j=0; (j < DIM_FAST); j++) {
-      load_table(collection, file, j, k);
-    };
-  };
+  load_tables(collection, file);
 }
 
 void initialise_tables_from_file(TableCollection *collection, char *filename) {

--- a/driver_table_reader.c
+++ b/driver_table_reader.c
@@ -3,9 +3,12 @@
 #include <stdlib.h>
 #include "driver_table_reader.h"
 
-// returns the index of the table in the collection
-// should automatically give the floor index
-// information about the logT and logR arrays is stored here
+// dimensions (number of) labels in logR
+#define DIM_FAST 56
+// dimensions (number of) labels in logT
+#define DIM_SLOW 22
+// returns the floor index of the table in the collection
+// assumes a particular distribution of labels in logT and logR
 int hash_label(double logT, double logR) {
   int index_j, index_k;
   index_j = (logR + 7.4) / 0.2;  
@@ -43,15 +46,15 @@ TableRow *get_table_row_from_key(TableCollection *collection, int i,
 // loads a 2D table into the memory specified by index j and k
 // from a file specified 
 void load_tables(TableCollection *collection, FILE *file) {
-  char buff[1024];
+  char buff[256];
 
   int i = 0;
   double logT, logR;
-  // condition to capture end of file and end of table
+  // keeps reading rows in the file until reaching end of file (EOF)
   while (fgets(buff, sizeof(buff), file)) {
     // check if the line starts with the comment line char
     if (buff[0]=='#') {
-      i = 0; // reset the energies index to 0
+      i = 0; // reset the row_label index since new table
       // some comment lines contain information about the table
       // this updates the array of log_Ts and log_Rs
       sscanf(buff, "%*s %lf %lf", &(logT), &(logR));
@@ -69,7 +72,6 @@ void load_tables(TableCollection *collection, FILE *file) {
       &row->entry[5]);
     i++;
   };
-  // printf("finished loading table %d\n", DIM_F * k + j + 1);
 }
 
 // requires manually calling free when done with the table

--- a/driver_table_reader.c
+++ b/driver_table_reader.c
@@ -62,14 +62,10 @@ void load_tables(TableCollection *collection, FILE *file) {
     };
 
     TableRow *row = get_table_row(collection, i, logT, logR);
+    double *entry = row->entry;
     sscanf(buff, "%lf %lf %lf %lf %lf %lf %lf", 
       &(collection->row_labels[i]),  // row label is the first entry
-      &row->entry[0], 
-      &row->entry[1], 
-      &row->entry[2], 
-      &row->entry[3], 
-      &row->entry[4], 
-      &row->entry[5]);
+      &entry[0], &entry[1], &entry[2], &entry[3], &entry[4], &entry[5]);
     i++;
   };
 }

--- a/driver_table_reader.c
+++ b/driver_table_reader.c
@@ -19,11 +19,11 @@ int hash_label(double logT, double logR) {
 // returns a pointer to a table in the collection
 // j is index in R (log_R)
 // k is index in temp (log_T K)
-SizedTable *get_table(TableCollection *collection, int j, int k) {
+SizedTable *get_table_from_index(TableCollection *collection, int j, int k) {
   return &(collection->table[DIM_FAST * k + j]);
 }
 
-SizedTable *get_table_from_key(TableCollection *collection, double logT, double logR) {
+SizedTable *get_table(TableCollection *collection, double logT, double logR) {
   int table_index = hash_label(logT, logR);
   return &(collection->table[table_index]);
 }
@@ -32,14 +32,14 @@ SizedTable *get_table_from_key(TableCollection *collection, double logT, double 
 // i is index in energy (log_E eV)
 // j is index in R (log_R)
 // k is index in temp (log_T K)
-TableRow *get_table_row(TableCollection *collection, int i, int j, int k) {
-  SizedTable *table = get_table(collection, j, k);
+TableRow *get_table_row_from_index(TableCollection *collection, int i, int j, int k) {
+  SizedTable *table = get_table_from_index(collection, j, k);
   return &(table->row[i]);
 }
 
-TableRow *get_table_row_from_key(TableCollection *collection, int i, 
+TableRow *get_table_row(TableCollection *collection, int i, 
                                  double logT, double logR) {
-  SizedTable *table = get_table_from_key(collection, logT, logR);
+  SizedTable *table = get_table(collection, logT, logR);
   return &(table->row[i]);
 }
 
@@ -61,7 +61,7 @@ void load_tables(TableCollection *collection, FILE *file) {
       continue;
     };
 
-    TableRow *row = get_table_row_from_key(collection, i, logT, logR);
+    TableRow *row = get_table_row(collection, i, logT, logR);
     sscanf(buff, "%lf %lf %lf %lf %lf %lf %lf", 
       &(collection->row_labels[i]),  // row label is the first entry
       &row->entry[0], 

--- a/driver_table_reader.h
+++ b/driver_table_reader.h
@@ -27,6 +27,8 @@ typedef struct TableCollection {
   double log_Rs[DIM_FAST];
 } TableCollection;
 
+TableRow *get_table_row_from_key(TableCollection *, int, double, double);
+
 TableRow *get_table_row(TableCollection *, int, int, int);
 
 void initialise_tables_from_file(TableCollection *, char *);

--- a/driver_table_reader.h
+++ b/driver_table_reader.h
@@ -6,8 +6,6 @@
 // giving the incorrect dimensions results in a garbled table
 #define DIM_ROWS 301
 #define DIM_COLS 6
-#define DIM_FAST 56
-#define DIM_SLOW 22
 // a row of data values
 // with known compile-time size
 typedef struct TableRow {

--- a/driver_table_reader.h
+++ b/driver_table_reader.h
@@ -4,27 +4,33 @@
 // currently the information about dimensions of the data
 // have to be given here:
 // giving the incorrect dimensions results in a garbled table
-#define DIM_R 301
-#define DIM_C 6
-#define DIM_F 56
-#define DIM_S 22
-// a data structure to hold the table information,
+#define DIM_ROWS 301
+#define DIM_COLS 6
+#define DIM_FAST 56
+#define DIM_SLOW 22
+// a row of data values
+// with known compile-time size
+typedef struct TableRow {
+  double entry[DIM_COLS];
+} TableRow;
+// 2D subtable with known compile-time size
+typedef struct SizedTable {
+  TableRow row[DIM_ROWS];
+} SizedTable;
+// a data structure to hold all the tables,
 // including the values of the headers
-struct Table {
-  double *data;
-  int stride_energy;
-  int stride_log_Rs;
-  int stride_log_Ts;
-  double energies[DIM_R];
-  double log_Ts[DIM_S];
-  double log_Rs[DIM_F];
-};
-typedef struct Table Table;
+// dynamically allocated at run-time
+typedef struct TableCollection {
+  double row_labels[DIM_ROWS];
+  SizedTable *table;
+  double log_Ts[DIM_SLOW];
+  double log_Rs[DIM_FAST];
+} TableCollection;
 
-double *get_table_row(Table *, int, int, int);
+TableRow *get_table_row(TableCollection *, int, int, int);
 
-void initialise_table_from_file(Table *, char *);
+void initialise_tables_from_file(TableCollection *, char *);
 
-void free_table(Table *);
+void drop_tables(TableCollection *);
 
 #endif // DRIVER_TABLE_READER_H_

--- a/driver_table_reader.h
+++ b/driver_table_reader.h
@@ -25,9 +25,9 @@ typedef struct TableCollection {
 
 int hash_label(double, double);
 
-TableRow *get_table_row_from_key(TableCollection *, int, double, double);
+TableRow *get_table_row(TableCollection *, int, double, double);
 
-TableRow *get_table_row(TableCollection *, int, int, int);
+TableRow *get_table_row_from_index(TableCollection *, int, int, int);
 
 void initialise_tables_from_file(TableCollection *, char *);
 

--- a/driver_table_reader.h
+++ b/driver_table_reader.h
@@ -23,8 +23,6 @@ typedef struct SizedTable {
 typedef struct TableCollection {
   double row_labels[DIM_ROWS];
   SizedTable *table;
-  double log_Ts[DIM_SLOW];
-  double log_Rs[DIM_FAST];
 } TableCollection;
 
 int hash_label(double, double);

--- a/driver_table_reader.h
+++ b/driver_table_reader.h
@@ -27,6 +27,8 @@ typedef struct TableCollection {
   double log_Rs[DIM_FAST];
 } TableCollection;
 
+int hash_label(double, double);
+
 TableRow *get_table_row_from_key(TableCollection *, int, double, double);
 
 TableRow *get_table_row(TableCollection *, int, int, int);

--- a/main.c
+++ b/main.c
@@ -15,7 +15,7 @@ int main() {
   TableRow *row = get_table_row(&collection, i, j, k);
   printf("For energy index = %d in table %d\n", i, DIM_FAST*k + j + 1);
   printf("log_T: %f and log_R: %f\n", collection.log_Ts[k], collection.log_Rs[j]);
-  printf("Energy[k] = %f, parameters: %f %f %f %f %f %f \n",
+  printf("Energy[k] = %f, parameters: %4.3e %4.3e %4.3e %4.3e %4.3e %4.3e \n",
         collection.row_labels[i],
         row->entry[0], 
         row->entry[1], 
@@ -23,12 +23,14 @@ int main() {
         row->entry[3],
         row->entry[4],
         row->entry[5]);
-  i = 6;
-  j = 0;
-  k = 0;
-  row = get_table_row_from_key(&collection, i, 4.91, -7.48);
-  printf("For energy index = %d in table %d\n", i, DIM_FAST*k + j + 1);
-  printf("log_T: %f and log_R: %f\n", collection.log_Ts[k], collection.log_Rs[j]);
+  i = 4;
+  j = 6;
+  k = 5;
+  double logT = 5.48;
+  double logR = -6.10;
+  row = get_table_row_from_key(&collection, i, logT, logR);
+  printf("For energy index = %d in table index: %d\n", i, hash_label(logT, logR));
+  printf("log_T: %f and log_R: %f\n", logT, logR);
   printf("Energy[k] = %f, parameters: %4.3e %4.3e %4.3e %4.3e %4.3e %4.3e \n",
          collection.row_labels[i], 
           row->entry[0], 

--- a/main.c
+++ b/main.c
@@ -14,7 +14,6 @@ int main() {
   k = 5;
   TableRow *row = get_table_row(&collection, i, j, k);
   printf("For energy index = %d in table %d\n", i, DIM_FAST*k + j + 1);
-  printf("log_T: %f and log_R: %f\n", collection.log_Ts[k], collection.log_Rs[j]);
   printf("Energy[k] = %f, parameters: %4.3e %4.3e %4.3e %4.3e %4.3e %4.3e \n",
         collection.row_labels[i],
         row->entry[0], 
@@ -24,8 +23,6 @@ int main() {
         row->entry[4],
         row->entry[5]);
   i = 4;
-  j = 6;
-  k = 5;
   double logT = 5.48;
   double logR = -6.10;
   row = get_table_row_from_key(&collection, i, logT, logR);

--- a/main.c
+++ b/main.c
@@ -26,7 +26,7 @@ int main() {
   i = 6;
   j = 0;
   k = 0;
-  row = get_table_row(&collection, i, j, k);
+  row = get_table_row_from_key(&collection, i, 4.91, -7.48);
   printf("For energy index = %d in table %d\n", i, DIM_FAST*k + j + 1);
   printf("log_T: %f and log_R: %f\n", collection.log_Ts[k], collection.log_Rs[j]);
   printf("Energy[k] = %f, parameters: %4.3e %4.3e %4.3e %4.3e %4.3e %4.3e \n",

--- a/main.c
+++ b/main.c
@@ -13,28 +13,21 @@ int main() {
   j = 6;
   k = 5;
   TableRow *row = get_table_row_from_index(&collection, i, j, k);
+  double *entry = row->entry;
   printf("Energy[k] = %f, parameters: %4.3e %4.3e %4.3e %4.3e %4.3e %4.3e \n",
-        collection.row_labels[i],
-        row->entry[0], 
-        row->entry[1], 
-        row->entry[2],
-        row->entry[3],
-        row->entry[4],
-        row->entry[5]);
+        collection.row_labels[i], 
+    entry[0], entry[1],  entry[2], entry[3], entry[4], entry[5]);
+
   i = 4;
   double logT = 5.48;
   double logR = -6.10;
   row = get_table_row(&collection, i, logT, logR);
+  entry = row->entry;
   printf("For energy index = %d in table index: %d\n", i, hash_label(logT, logR));
   printf("log_T: %f and log_R: %f\n", logT, logR);
   printf("Energy[k] = %f, parameters: %4.3e %4.3e %4.3e %4.3e %4.3e %4.3e \n",
          collection.row_labels[i], 
-          row->entry[0], 
-          row->entry[1], 
-          row->entry[2], 
-          row->entry[3], 
-          row->entry[4], 
-          row->entry[5]);
+          entry[0], entry[1], entry[2], entry[3], entry[4], entry[5]);
 
   drop_tables(&collection);
 

--- a/main.c
+++ b/main.c
@@ -13,7 +13,6 @@ int main() {
   j = 6;
   k = 5;
   TableRow *row = get_table_row(&collection, i, j, k);
-  printf("For energy index = %d in table %d\n", i, DIM_FAST*k + j + 1);
   printf("Energy[k] = %f, parameters: %4.3e %4.3e %4.3e %4.3e %4.3e %4.3e \n",
         collection.row_labels[i],
         row->entry[0], 

--- a/main.c
+++ b/main.c
@@ -12,7 +12,7 @@ int main() {
   i = 4;
   j = 6;
   k = 5;
-  TableRow *row = get_table_row(&collection, i, j, k);
+  TableRow *row = get_table_row_from_index(&collection, i, j, k);
   printf("Energy[k] = %f, parameters: %4.3e %4.3e %4.3e %4.3e %4.3e %4.3e \n",
         collection.row_labels[i],
         row->entry[0], 
@@ -24,7 +24,7 @@ int main() {
   i = 4;
   double logT = 5.48;
   double logR = -6.10;
-  row = get_table_row_from_key(&collection, i, logT, logR);
+  row = get_table_row(&collection, i, logT, logR);
   printf("For energy index = %d in table index: %d\n", i, hash_label(logT, logR));
   printf("log_T: %f and log_R: %f\n", logT, logR);
   printf("Energy[k] = %f, parameters: %4.3e %4.3e %4.3e %4.3e %4.3e %4.3e \n",

--- a/main.c
+++ b/main.c
@@ -4,29 +4,42 @@
 
 int main() {
   int i, j, k;
-  Table boxed_table;
+  TableCollection collection;
 
-  initialise_table_from_file(&boxed_table, "op10_5.dat");
+  initialise_tables_from_file(&collection, "op10_5.dat");
 
   // test getting some of the table values after initialisation:
   i = 4;
   j = 6;
   k = 5;
-  double *row = get_table_row(&boxed_table, i, j, k);
-  printf("For energy index = %d in table %d\n", i, DIM_F*k + j + 1);
-  printf("log_T: %f and log_R: %f\n", boxed_table.log_Ts[k], boxed_table.log_Rs[j]);
+  TableRow *row = get_table_row(&collection, i, j, k);
+  printf("For energy index = %d in table %d\n", i, DIM_FAST*k + j + 1);
+  printf("log_T: %f and log_R: %f\n", collection.log_Ts[k], collection.log_Rs[j]);
   printf("Energy[k] = %f, parameters: %f %f %f %f %f %f \n",
-         boxed_table.energies[i], row[0], row[1], row[2], row[3], row[4], row[5]);
+        collection.row_labels[i],
+        row->entry[0], 
+        row->entry[1], 
+        row->entry[2],
+        row->entry[3],
+        row->entry[4],
+        row->entry[5]);
   i = 6;
   j = 0;
   k = 0;
-  row = get_table_row(&boxed_table, i, j, k);
-  printf("For energy index = %d in table %d\n", i, DIM_F*k + j + 1);
-  printf("log_T: %f and log_R: %f\n", boxed_table.log_Ts[k], boxed_table.log_Rs[j]);
+  row = get_table_row(&collection, i, j, k);
+  printf("For energy index = %d in table %d\n", i, DIM_FAST*k + j + 1);
+  printf("log_T: %f and log_R: %f\n", collection.log_Ts[k], collection.log_Rs[j]);
   printf("Energy[k] = %f, parameters: %4.3e %4.3e %4.3e %4.3e %4.3e %4.3e \n",
-         boxed_table.energies[i], row[0], row[1], row[2], row[3], row[4], row[5]);
+         collection.row_labels[i], 
+          row->entry[0], 
+          row->entry[1], 
+          row->entry[2], 
+          row->entry[3], 
+          row->entry[4], 
+          row->entry[5]);
 
-  free_table(&boxed_table);
+  drop_tables(&collection);
+
   return 0;
 
 }


### PR DESCRIPTION
Closes #4.

The collection of all the 2D tables (each one separated by comments in the file) is stored as a sort of hashed collection. To get the index of the 2D table (with a particular `logT` and `logR`) in the collection, the `hash_label` function can be called. It always returns the lower index. This hashing is faster than the comparison algorithm.