### PR TITLE
Add makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: clean, test, test-run
 
-CC := gcc
+CC ?= gcc
 CFLAGS := -Wextra -Wall -Wconversion -Wcast-align -Wstrict-prototypes
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: clean, test, test-run
+
+CC := gcc
+CFLAGS := -Wextra -Wall -Wconversion -Wcast-align -Wstrict-prototypes
+
+clean:
+	rm ./test
+
+test: main.c driver_table_reader.c
+	$(CC) $(CFLAGS) -o test main.c driver_table_reader.c
+
+test-run: test
+	./test

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: clean, test, test-run
 
-CC ?= gcc
+CC ?= clang
 CFLAGS := -Wextra -Wall -Wconversion -Wcast-align -Wstrict-prototypes
 
 clean:


### PR DESCRIPTION
Closes #6.

Now `make test` creates the `./test` binary without having to write out the whole command. It includes the use of flags for the compiler with extra warnings. 

The default compiler is set as `CC ?= gcc` but can be changed in a session, e.g. to the `clang` compiler by`export CC=clang`.

`make clean` removes the `./test` binary and `make test-run` can be invoked to compile then immediately run.